### PR TITLE
Fix missing project action after clicking Save in project configuration

### DIFF
--- a/src/main/java/hudson/plugins/nunit/NUnitPublisher.java
+++ b/src/main/java/hudson/plugins/nunit/NUnitPublisher.java
@@ -95,7 +95,7 @@ public class NUnitPublisher extends Recorder implements Serializable {
         if (action == null) {
             return new TestResultProjectAction(project);
         } else {
-            return null;
+            return action;
         }
     }
 


### PR DESCRIPTION
When you have a brand new project, your action is null. So getProjectAction returns a new action. But when your project has already a project action, the plug-in is returning null, what causes the Jenkins UI to 'disappear' with the graph.

Then you have to click Save again. Now your action is null again, so it will be recreated...and it all starts over again...

This pull request fixes this scenario by returning the already created project action, instead of null :o)
