### PR TITLE
Do not wait for checkpoint from previous build

### DIFF
--- a/src/main/java/hudson/plugins/nunit/NUnitPublisher.java
+++ b/src/main/java/hudson/plugins/nunit/NUnitPublisher.java
@@ -126,7 +126,7 @@ public class NUnitPublisher extends Recorder implements Serializable {
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     @Override


### PR DESCRIPTION
Fixes an issue with result archiver getting stuck for a long time in concurrent builds.
A similar issue has been fixed in the JUnit Jenkins plugin:

https://issues.jenkins-ci.org/browse/JENKINS-10234
https://github.com/jenkinsci/jenkins/commit/90ff9f806fcac1a58f4bd40bfcc4ed5273ff116a