### PR TITLE
adaption to new jenkins step definitions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-core</artifactId>
+			<version>1.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.jmock</groupId>
 			<artifactId>jmock-legacy</artifactId>
 			<version>2.2.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.13</version>
+            <version>1.14</version>
         </dependency>
         <!-- testing -->
 		<dependency>

--- a/src/main/java/hudson/plugins/nunit/NUnitArchiver.java
+++ b/src/main/java/hudson/plugins/nunit/NUnitArchiver.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
+import hudson.model.TaskListener;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.types.FileSet;
 import org.jenkinsci.remoting.RoleChecker;
@@ -32,7 +33,7 @@ public class NUnitArchiver implements FilePath.FileCallable<Boolean>, Serializab
     public static final String JUNIT_REPORTS_PATH = "temporary-junit-reports";
 
     // Build related objects
-    private final BuildListener listener;
+    private final TaskListener listener;
     private final String testResultsPattern;
 
     private TestReportTransformer unitReportTransformer;
@@ -44,7 +45,7 @@ public class NUnitArchiver implements FilePath.FileCallable<Boolean>, Serializab
     	this(listener, testResults, unitReportTransformer, true);
     }
     
-    public NUnitArchiver(BuildListener listener, String testResults, TestReportTransformer unitReportTransformer, Boolean failIfNoResults) throws TransformerException {
+    public NUnitArchiver(TaskListener listener, String testResults, TestReportTransformer unitReportTransformer, Boolean failIfNoResults) throws TransformerException {
         this.listener = listener;
         this.testResultsPattern = testResults;
         this.unitReportTransformer = unitReportTransformer;

--- a/src/main/java/hudson/plugins/nunit/NUnitPublisher.java
+++ b/src/main/java/hudson/plugins/nunit/NUnitPublisher.java
@@ -4,8 +4,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 
+import javax.annotation.Nonnull;
 import javax.xml.transform.TransformerException;
 
+import hudson.*;
+import hudson.model.*;
+import jenkins.tasks.SimpleBuildStep;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.types.FileSet;
@@ -13,17 +17,7 @@ import org.jenkinsci.remoting.RoleChecker;
 import org.jenkinsci.remoting.RoleSensitive;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import hudson.AbortException;
-import hudson.EnvVars;
-import hudson.Extension;
 import hudson.FilePath.FileCallable;
-import hudson.Launcher;
-import hudson.Util;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Action;
-import hudson.model.BuildListener;
-import hudson.model.Result;
 import hudson.remoting.VirtualChannel;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
@@ -39,7 +33,7 @@ import jenkins.security.Roles;
  * 
  * @author Erik Ramfelt
  */
-public class NUnitPublisher extends Recorder implements Serializable {
+public class NUnitPublisher extends Recorder implements Serializable, SimpleBuildStep {
 
     private static final long serialVersionUID = 1L;
 
@@ -152,7 +146,7 @@ public class NUnitPublisher extends Recorder implements Serializable {
                     listener.getLogger().println("Skipping feeding JUnit reports to JUnitArchiver");
                 } else {
                     // Run the JUnit test archiver
-                    result = recordTestResult(NUnitArchiver.JUNIT_REPORTS_PATH + "/TEST-*.xml", build, listener);
+                    result = recordTestResult(NUnitArchiver.JUNIT_REPORTS_PATH + "/TEST-*.xml", build, listener, build.getWorkspace());
                 }
                 
                 if (keepJUnitReports) {
@@ -178,7 +172,7 @@ public class NUnitPublisher extends Recorder implements Serializable {
      * @throws InterruptedException
      * @throws IOException
      */
-    private boolean recordTestResult(String junitFilePattern, AbstractBuild<?, ?> build, BuildListener listener)
+    private boolean recordTestResult(String junitFilePattern, Run<?, ?> build, TaskListener listener, FilePath filePath)
             throws InterruptedException, IOException {
         TestResultAction existingAction = build.getAction(TestResultAction.class);
         TestResultAction action;
@@ -189,7 +183,7 @@ public class NUnitPublisher extends Recorder implements Serializable {
         if (existingAction != null) {
             existingTestResults = existingAction.getResult();
         }
-        TestResult result = getTestResult(junitFilePattern, build, existingTestResults, buildTime);
+        TestResult result = getTestResult(junitFilePattern, build, existingTestResults, buildTime, filePath);
 
         if (existingAction == null) {
             action = new TestResultAction(build, result, listener);
@@ -224,9 +218,9 @@ public class NUnitPublisher extends Recorder implements Serializable {
      * @throws IOException
      * @throws InterruptedException
      */
-    private TestResult getTestResult(final String junitFilePattern, AbstractBuild<?, ?> build,
-            final TestResult existingTestResults, final long buildTime) throws IOException, InterruptedException {
-        TestResult result = build.getWorkspace().act(new FileCallable<TestResult>() {
+    private TestResult getTestResult(final String junitFilePattern, Run<?, ?> build,
+            final TestResult existingTestResults, final long buildTime, FilePath filePath) throws IOException, InterruptedException {
+        TestResult result = filePath.act(new FileCallable<TestResult>() {
 			private static final long serialVersionUID = -8917897415838795523L;
 
 			public TestResult invoke(File ws, VirtualChannel channel) throws IOException {
@@ -264,6 +258,40 @@ public class NUnitPublisher extends Recorder implements Serializable {
     @Override
     public BuildStepDescriptor<Publisher> getDescriptor() {
         return DESCRIPTOR;
+    }
+
+    @Override
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener taskListener) throws InterruptedException, IOException {
+        if (debug) {
+            taskListener.getLogger().println("NUnit publisher running in debug mode.");
+        }
+        boolean result = true;
+        try {
+            EnvVars env = run.getEnvironment(taskListener);
+            String resolvedTestResultsPattern = env.expand(testResultsPattern);
+
+            taskListener.getLogger().println("Recording NUnit tests results");
+            NUnitArchiver transformer = new NUnitArchiver(taskListener, resolvedTestResultsPattern, new NUnitReportTransformer(), failIfNoResults);
+            result = filePath.act(transformer);
+
+            if (result) {
+                if (skipJUnitArchiver) {
+                    taskListener.getLogger().println("Skipping feeding JUnit reports to JUnitArchiver");
+                } else {
+                    // Run the JUnit test archiver
+                    result = recordTestResult(NUnitArchiver.JUNIT_REPORTS_PATH + "/TEST-*.xml", run, taskListener, filePath);
+                }
+
+                if (keepJUnitReports) {
+                    taskListener.getLogger().println("Skipping deletion of temporary JUnit reports.");
+                } else {
+                    filePath.child(NUnitArchiver.JUNIT_REPORTS_PATH).deleteRecursive();
+                }
+            }
+
+        } catch (TransformerException te) {
+            throw new AbortException("Could not read the XSL XML file. Please report this issue to the plugin author");
+        }
     }
 
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {


### PR DESCRIPTION
I implemented the interface SimpleBuildStep to make it available for pipeline scripts.

you can now include it inside your Jenkinsfile like:

step([$class: 'NUnitPublisher', testResultsPattern: '**/TestResults/*.xml', debug: false, keepJUnitReports: true, skipJUnitArchiver:false, failIfNoResults: true])		