### PR TITLE
Added support for NUnit3

### DIFF
--- a/src/main/java/hudson/plugins/nunit/NUnitReportTransformer.java
+++ b/src/main/java/hudson/plugins/nunit/NUnitReportTransformer.java
@@ -40,9 +40,11 @@ public class NUnitReportTransformer implements TestReportTransformer, Serializab
 
     private static final String TEMP_JUNIT_FILE_STR = "temp-junit.xml";
     public static final String NUNIT_TO_JUNIT_XSLFILE_STR = "nunit-to-junit.xsl";
+    public static final String NUNIT3_TO_JUNIT_XSLFILE_STR = "nunit3-junit.xslt";
 
     private transient boolean xslIsInitialized;
     private transient Transformer nunitTransformer;
+    private transient Transformer nunit3Transformer;
     private transient Transformer writerTransformer;
     private transient DocumentBuilder xmlDocumentBuilder;
     private transient int transformCount;
@@ -62,10 +64,11 @@ public class NUnitReportTransformer implements TestReportTransformer, Serializab
         
         initialize();
         
+        Document nunitDocument = xmlDocumentBuilder.parse(nunitFileStream);
         File junitTargetFile = new File(junitOutputPath, TEMP_JUNIT_FILE_STR);
         FileOutputStream fileOutputStream = new FileOutputStream(junitTargetFile);
         try {
-            nunitTransformer.transform(new StreamSource(nunitFileStream), new StreamResult(fileOutputStream));
+            getNunitTransformer(nunitDocument).transform(new DOMSource(nunitDocument), new StreamResult(fileOutputStream));
         } finally {
             fileOutputStream.close();
         }
@@ -78,6 +81,7 @@ public class NUnitReportTransformer implements TestReportTransformer, Serializab
         if (!xslIsInitialized) {
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
             nunitTransformer = transformerFactory.newTransformer(new StreamSource(this.getClass().getResourceAsStream(NUNIT_TO_JUNIT_XSLFILE_STR)));
+            nunit3Transformer = transformerFactory.newTransformer(new StreamSource(this.getClass().getResourceAsStream(NUNIT3_TO_JUNIT_XSLFILE_STR)));
             writerTransformer = transformerFactory.newTransformer();
     
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -85,6 +89,13 @@ public class NUnitReportTransformer implements TestReportTransformer, Serializab
             
             xslIsInitialized = true;
         }
+    }
+
+    private Transformer getNunitTransformer(Document nunitDocument) {
+        if ("test-run".equals(nunitDocument.getDocumentElement().getNodeName())) {
+            return nunit3Transformer;
+        }
+        return nunitTransformer;
     }
 
     /**

--- a/src/main/resources/hudson/plugins/nunit/nunit3-junit.xslt
+++ b/src/main/resources/hudson/plugins/nunit/nunit3-junit.xslt
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <!--
+    File created by Paul Hicks, and downloaded from
+    https://github.com/nunit/nunit-transforms/blob/master/nunit3-junit/nunit3-junit.xslt
+  -->
+  <xsl:output method="xml" indent="yes"/>
+
+  <xsl:template match="/test-run">
+    <testsuites tests="{@testcasecount}" failures="{@failed}" disabled="{@skipped}" time="{@duration}">
+      <xsl:apply-templates/>
+    </testsuites>
+  </xsl:template>
+
+  <xsl:template match="test-suite">
+    <xsl:if test="test-case">
+      <testsuite tests="{@testcasecount}" time="{@duration}" errors="{@testcasecount - @passed - @skipped - @failed}" failures="{@failed}" skipped="{@skipped}" timestamp="{@start-time}">
+        <xsl:attribute name="name">
+          <xsl:for-each select="ancestor-or-self::test-suite/@name">
+            <xsl:value-of select="concat(., '.')"/>
+          </xsl:for-each>
+        </xsl:attribute>
+        <xsl:apply-templates select="test-case"/>
+      </testsuite>
+      <xsl:apply-templates select="test-suite"/>
+    </xsl:if>
+    <xsl:if test="not(test-case)">
+      <xsl:apply-templates/>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="test-case">
+    <testcase name="{@name}" assertions="{@asserts}" time="{@duration}" status="{@result}" classname="{@classname}">
+      <xsl:if test="@runstate = 'Skipped' or @runstate = 'Ignored'">
+        <skipped/>
+      </xsl:if>
+      
+      <xsl:apply-templates/>
+    </testcase>
+  </xsl:template>
+
+  <xsl:template match="command-line"/>
+  <xsl:template match="settings"/>
+
+  <xsl:template match="output">
+    <system-out>
+      <xsl:value-of select="output"/>
+    </system-out>
+  </xsl:template>
+
+  <xsl:template match="stack-trace">
+  </xsl:template>
+
+  <xsl:template match="test-case/failure">
+    <failure message="{./message}">
+      <xsl:value-of select="./stack-trace"/>
+    </failure>
+  </xsl:template>
+
+  <xsl:template match="test-suite/failure"/>
+
+  <xsl:template match="test-case/reason">
+    <skipped message="{./message}"/>
+  </xsl:template>
+
+  <xsl:template match="test-suite/reason"/>
+
+  <xsl:template match="properties"/>
+</xsl:stylesheet>
+


### PR DESCRIPTION
In response to https://issues.jenkins-ci.org/browse/JENKINS-27906, I've taken the XSLT file from Paul Hicks and hooked it into NUnitReportTransformer. If the NUnit document has root element "test-run" it will use the NUnit3 XSLT file, otherwise it will assume NUnit2 and perform as before.

I've tested this locally with an NUnit3 report file, and it splits the one file into many others.