### PR TITLE
Changing classname to fullname

### DIFF
--- a/src/main/resources/hudson/plugins/nunit/nunit-to-junit.xsl
+++ b/src/main/resources/hudson/plugins/nunit/nunit-to-junit.xsl
@@ -115,7 +115,7 @@ STACK TRACE:
 	</xsl:template>
 
 	<xsl:template match="test-case">
-		<testcase name="{@name}" assertions="{@asserts}" time="{@duration}" status="{@result}" classname="{@classname}">
+		<testcase name="{@name}" assertions="{@asserts}" time="{@duration}" status="{@result}" classname="{@fullname}">
 			<xsl:if test="@runstate = 'Skipped' or @runstate = 'Ignored' or @runstate='Inconclusive'">
 				<skipped/>
 			</xsl:if>


### PR DESCRIPTION
Changing the classname to fullname in the xsl conversion to better support tests that use derived classes.