### PR TITLE
Don't overwrite previously recorded tests results

### DIFF
--- a/src/main/java/hudson/plugins/nunit/NUnitArchiver.java
+++ b/src/main/java/hudson/plugins/nunit/NUnitArchiver.java
@@ -72,7 +72,7 @@ public class NUnitArchiver extends MasterToSlaveCallable<Boolean, IOException> {
                             "Could not initialize the XML parser. Please report this issue to the plugin author", pce);
                 }
             }
-        } else if(this.failIfNoResults) {
+        } else {
             retValue = false;
         }
 

--- a/src/main/java/hudson/plugins/nunit/NUnitPublisher.java
+++ b/src/main/java/hudson/plugins/nunit/NUnitPublisher.java
@@ -313,8 +313,10 @@ public class NUnitPublisher extends Recorder implements Serializable, SimpleBuil
                     ws.child(NUnitArchiver.JUNIT_REPORTS_PATH).deleteRecursive();
                 }
             } else {
-                // this should only happen if failIfNoResults is true and there are no result files, see NUnitArchiver.
-                run.setResult(Result.FAILURE);
+                if (this.getFailIfNoResults()) {
+                    // this should only happen if failIfNoResults is true and there are no result files, see NUnitArchiver.
+                    run.setResult(Result.FAILURE);
+                }
             }
         } catch(AbortException e) {
             // this is used internally to signal issues, so we just rethrow instead of letting the IOException


### PR DESCRIPTION
Don't overwrite previously recorded tests results if another publishing was called but no files were found by the provided filter

There is a bug - if you call nunit results publisher twice and if
first publish was successful and recorded some results and the
second publish is executed for non-existing file - the result will be
overridden and will be "No tests results". Don't call recordTestResult in
case if there are no nunit tests results to don't overwrite existing
test results.