### PR TITLE
Handle NUnit tests with status 'Warning'

### DIFF
--- a/src/main/java/hudson/plugins/nunit/NUnitArchiver.java
+++ b/src/main/java/hudson/plugins/nunit/NUnitArchiver.java
@@ -48,7 +48,7 @@ public class NUnitArchiver extends MasterToSlaveCallable<Boolean, IOException> {
         this.testResultsPattern = testResultsPattern;
         this.unitReportTransformer = unitReportTransformer;
         this.failIfNoResults = failIfNoResults;
-        this.warningNUnitTestResultHanlingBehavior = "skipped";
+        this.warningNUnitTestResultHandlingBehavior = "skipped";
     }
 
     public NUnitArchiver(String root, TaskListener listener, String testResultsPattern, TestReportTransformer unitReportTransformer, boolean failIfNoResults, String warningNUnitTestResultHanlingBehavior) {

--- a/src/main/java/hudson/plugins/nunit/NUnitReportTransformer.java
+++ b/src/main/java/hudson/plugins/nunit/NUnitReportTransformer.java
@@ -1,6 +1,7 @@
 package hudson.plugins.nunit;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,10 +45,13 @@ public class NUnitReportTransformer implements TestReportTransformer, Serializab
 
     private static final int MAX_PATH = 255;
     private static final String TEMP_JUNIT_FILE_STR = "temp-junit.xml";
+    private static final String TEMP_XUNIT_WARNING_TO_FAIL_FILE_STR = "temp-xunit-warnings-to-fail.xml";
+    public static final String NUNIT_WARN_TO_NUNIT_FAIL_XSLFILE_STR = "nunit-warn-to-fail.xsl";
     public static final String NUNIT_TO_JUNIT_XSLFILE_STR = "nunit-to-junit.xsl";
 
     private transient boolean xslIsInitialized;
     private transient Transformer nunitTransformer;
+    private transient Transformer nunitWarningToFailTransformer;
     private transient Transformer writerTransformer;
     private transient DocumentBuilder xmlDocumentBuilder;
     private transient int transformCount;
@@ -62,15 +66,48 @@ public class NUnitReportTransformer implements TestReportTransformer, Serializab
      * @throws SAXException
      * @throws ParserConfigurationException 
      */
+    @Deprecated
     public void transform(InputStream nunitFileStream, File junitOutputPath) throws IOException, TransformerException,
+            SAXException, ParserConfigurationException {
+            
+        transform(nunitFileStream,junitOutputPath, false);
+    }
+
+    /**
+     * Transform the nunit file into several junit files in the output path
+     * 
+     * @param nunitFileStream the nunit file stream to transform
+     * @param junitOutputPath the output path to put all junit files
+     * @param convertNUnitWarningsToFailures Convert NUnit Warnings to Failures 
+     * @throws IOException thrown if there was any problem with the transform.
+     * @throws TransformerException
+     * @throws SAXException
+     * @throws ParserConfigurationException 
+     */
+    public void transform(InputStream nunitFileStream, File junitOutputPath, boolean convertNUnitWarningsToFailures) throws IOException, TransformerException,
             SAXException, ParserConfigurationException {
         
         initialize();
         
         File junitTargetFile = new File(junitOutputPath, TEMP_JUNIT_FILE_STR);
         FileOutputStream fileOutputStream = new FileOutputStream(junitTargetFile);
+        InputStream is;
         try {
-            InputStream is = new InvalidXmlInputStream(new BOMInputStream(nunitFileStream), '?');
+            if (convertNUnitWarningsToFailures)
+            {
+                // Transform NUnit warnings to failures first, if requested.
+                File tempNUnitWarningsToFail = new File(junitOutputPath, TEMP_XUNIT_WARNING_TO_FAIL_FILE_STR);
+                FileOutputStream tempNunitFileOutputStream = new FileOutputStream(tempNUnitWarningsToFail);
+                InputStream nunitIs = new InvalidXmlInputStream(new BOMInputStream(nunitFileStream), '?');
+                nunitWarningToFailTransformer.transform(new StreamSource(nunitIs), new StreamResult(tempNunitFileOutputStream));
+                FileInputStream fileStream = new FileInputStream(tempNUnitWarningsToFail);
+                is = new InvalidXmlInputStream(new BOMInputStream(fileStream), '?');
+               
+            }
+            else {
+                // Read the NUnit report "as-is" without first transforming warnings to failures
+                is = new InvalidXmlInputStream(new BOMInputStream(nunitFileStream), '?');
+            }
             nunitTransformer.transform(new StreamSource(is), new StreamResult(fileOutputStream));
         } finally {
             fileOutputStream.close();
@@ -83,6 +120,7 @@ public class NUnitReportTransformer implements TestReportTransformer, Serializab
             ParserConfigurationException {
         if (!xslIsInitialized) {
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            nunitWarningToFailTransformer = transformerFactory.newTransformer(new StreamSource(this.getClass().getResourceAsStream(NUNIT_WARN_TO_NUNIT_FAIL_XSLFILE_STR)));
             nunitTransformer = transformerFactory.newTransformer(new StreamSource(this.getClass().getResourceAsStream(NUNIT_TO_JUNIT_XSLFILE_STR)));
             writerTransformer = transformerFactory.newTransformer();
     

--- a/src/main/java/hudson/plugins/nunit/NUnitReportTransformer.java
+++ b/src/main/java/hudson/plugins/nunit/NUnitReportTransformer.java
@@ -91,13 +91,14 @@ public class NUnitReportTransformer implements TestReportTransformer, Serializab
         
         File junitTargetFile = new File(junitOutputPath, TEMP_JUNIT_FILE_STR);
         FileOutputStream fileOutputStream = new FileOutputStream(junitTargetFile);
+        FileOutputStream tempNunitFileOutputStream = null;
         InputStream is;
         try {
             if (convertNUnitWarningsToFailures)
             {
                 // Transform NUnit warnings to failures first, if requested.
                 File tempNUnitWarningsToFail = new File(junitOutputPath, TEMP_XUNIT_WARNING_TO_FAIL_FILE_STR);
-                FileOutputStream tempNunitFileOutputStream = new FileOutputStream(tempNUnitWarningsToFail);
+                tempNunitFileOutputStream = new FileOutputStream(tempNUnitWarningsToFail);
                 InputStream nunitIs = new InvalidXmlInputStream(new BOMInputStream(nunitFileStream), '?');
                 nunitWarningToFailTransformer.transform(new StreamSource(nunitIs), new StreamResult(tempNunitFileOutputStream));
                 FileInputStream fileStream = new FileInputStream(tempNUnitWarningsToFail);
@@ -111,6 +112,10 @@ public class NUnitReportTransformer implements TestReportTransformer, Serializab
             nunitTransformer.transform(new StreamSource(is), new StreamResult(fileOutputStream));
         } finally {
             fileOutputStream.close();
+            if (tempNunitFileOutputStream != null) {
+                tempNunitFileOutputStream.close();
+            }
+            
         }
         splitJUnitFile(junitTargetFile, junitOutputPath);
         junitTargetFile.delete();

--- a/src/main/java/hudson/plugins/nunit/TestReportTransformer.java
+++ b/src/main/java/hudson/plugins/nunit/TestReportTransformer.java
@@ -22,4 +22,15 @@ public interface TestReportTransformer {
      */
     void transform(InputStream nunitFileStream, File junitOutputPath) throws IOException, TransformerException,
             SAXException, ParserConfigurationException;
+
+    /**
+     * Transforms the nunit file stream to junit files in the specified output path
+     * 
+     * @param nunitFileStream nunit report file stream
+     * @param junitOutputPath the output path to store junit reports to
+     * @param convertNUnitWarningsToFailures Convert NUnit Warnings to Failures 
+     * @throws ParserConfigurationException 
+     */
+    void transform(InputStream nunitFileStream, File junitOutputPath, boolean convertNUnitWarningsToFailures) throws IOException, TransformerException,
+            SAXException, ParserConfigurationException;
 }

--- a/src/main/resources/hudson/plugins/nunit/nunit-to-junit.xsl
+++ b/src/main/resources/hudson/plugins/nunit/nunit-to-junit.xsl
@@ -135,11 +135,12 @@ STACK TRACE:
 
 	<xsl:template match="test-case">
 		<xsl:variable name="newStatus">
-			 <xsl:call-template name="string-replace-all">
-					<xsl:with-param name="text" select="@result" />
-					<xsl:with-param name="replace" select="'Warning'" />
-					<xsl:with-param name="by" select="'Fail'" />
-				</xsl:call-template>
+			<!-- source: https://stackoverflow.com/a/10528912 -->
+			<xsl:call-template name="string-replace-all">
+				<xsl:with-param name="text" select="@result" />
+				<xsl:with-param name="replace" select="'Warning'" />
+				<xsl:with-param name="by" select="'Fail'" />
+			</xsl:call-template>
 		</xsl:variable>
 		<testcase name="{@name}" assertions="{@asserts}" time="{@duration}" status="{$newStatus}" classname="{@classname}">
 			<xsl:if test="@runstate = 'Skipped' or @runstate = 'Ignored' or @runstate='Inconclusive'">
@@ -211,6 +212,7 @@ This test case was reported as a "Warning" in NUnit, but converted to "Fail" by 
 		</xsl:choose>
 	</xsl:template>
 
+	<!-- source: https://stackoverflow.com/a/10528912 -->
 	<xsl:template name="string-replace-all">
 		<xsl:param name="text" />
 		<xsl:param name="replace" />
@@ -230,7 +232,4 @@ This test case was reported as a "Warning" in NUnit, but converted to "Fail" by 
 			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>
-
-
-
 </xsl:stylesheet>

--- a/src/main/resources/hudson/plugins/nunit/nunit-to-junit.xsl
+++ b/src/main/resources/hudson/plugins/nunit/nunit-to-junit.xsl
@@ -108,7 +108,7 @@ STACK TRACE:
 
 	<!-- NUnit3 results format -->
 	<xsl:template match="/test-run">
-		<testsuites tests="{@testcasecount}" failures="{@failed }" disabled="{@skipped}" time="{@duration}">
+		<testsuites tests="{@testcasecount}" failures="{@failed + count(//test-case[@result='Warning']) }" disabled="{@skipped}" time="{@duration}">
 			<xsl:apply-templates/>
 		</testsuites>
 	</xsl:template>
@@ -156,9 +156,7 @@ STACK TRACE:
 	<xsl:template match="output">
 		<system-out>
 			<xsl:copy-of select="./text()" />
-			<xsl:if test="../@result ='Warning'">
-			This test case was reported as a "Warning" in NUnit, but converted to "Fail" by Jenkins NUnuit Plugin
-			</xsl:if>
+			
 		</system-out>
 	</xsl:template>
 
@@ -174,7 +172,16 @@ STACK TRACE:
 	<xsl:template match="test-suite/failure"/>
 
 	<xsl:template match="test-case/reason">
-		<skipped message="{./message}"/>
+		 <xsl:choose>
+    		<xsl:when test="../@result ='Warning'">
+				<failure message="{./message}">
+This test case was reported as a "Warning" in NUnit, but converted to "Fail" by Jenkins NUnuit Plugin
+				</failure>
+			</xsl:when>
+			<xsl:otherwise>
+				<skipped message="{./message}"/>
+			</xsl:otherwise>
+		</xsl:choose>
 	</xsl:template>
 
 	<xsl:template match="test-suite/reason"/>

--- a/src/main/resources/hudson/plugins/nunit/nunit-to-junit.xsl
+++ b/src/main/resources/hudson/plugins/nunit/nunit-to-junit.xsl
@@ -108,14 +108,14 @@ STACK TRACE:
 
 	<!-- NUnit3 results format -->
 	<xsl:template match="/test-run">
-		<testsuites tests="{@testcasecount}" failures="{@failed + count(//test-case[@result='Warning']) }" disabled="{@skipped}" time="{@duration}">
+		<testsuites tests="{@testcasecount}" failures="{@failed}" disabled="{@skipped}" time="{@duration}">
 			<xsl:apply-templates/>
 		</testsuites>
 	</xsl:template>
 
 	<xsl:template match="test-suite">
 		<xsl:if test="test-case">
-			<testsuite tests="{@testcasecount}" time="{@duration}" errors="{@testcasecount - @passed - @skipped - @failed - @inconclusive - @warnings}" failures="{@failed + @warnings}" skipped="{@skipped + @inconclusive}" timestamp="{@start-time}">
+			<testsuite tests="{@testcasecount}" time="{@duration}" errors="{@testcasecount - @passed - @skipped - @failed - @inconclusive}" failures="{@failed}" skipped="{@skipped + @inconclusive}" timestamp="{@start-time}">
 				<xsl:attribute name="name">
 					<xsl:for-each select="ancestor-or-self::test-suite/@name">
 						<xsl:value-of select="concat(., '.')"/>
@@ -134,15 +134,7 @@ STACK TRACE:
 	</xsl:template>
 
 	<xsl:template match="test-case">
-		<xsl:variable name="newStatus">
-			<!-- source: https://stackoverflow.com/a/10528912 -->
-			<xsl:call-template name="string-replace-all">
-				<xsl:with-param name="text" select="@result" />
-				<xsl:with-param name="replace" select="'Warning'" />
-				<xsl:with-param name="by" select="'Fail'" />
-			</xsl:call-template>
-		</xsl:variable>
-		<testcase name="{@name}" assertions="{@asserts}" time="{@duration}" status="{$newStatus}" classname="{@classname}">
+		<testcase name="{@name}" assertions="{@asserts}" time="{@duration}" status="{@result}" classname="{@classname}">
 			<xsl:if test="@runstate = 'Skipped' or @runstate = 'Ignored' or @runstate='Inconclusive'">
 				<skipped/>
 			</xsl:if>
@@ -157,7 +149,6 @@ STACK TRACE:
 	<xsl:template match="output">
 		<system-out>
 			<xsl:copy-of select="./text()" />
-			
 		</system-out>
 	</xsl:template>
 
@@ -173,16 +164,7 @@ STACK TRACE:
 	<xsl:template match="test-suite/failure"/>
 
 	<xsl:template match="test-case/reason">
-		 <xsl:choose>
-    		<xsl:when test="../@result ='Warning'">
-				<failure message="{./message}">
-This test case was reported as a "Warning" in NUnit, but converted to "Fail" by Jenkins NUnuit Plugin
-				</failure>
-			</xsl:when>
-			<xsl:otherwise>
-				<skipped message="{./message}"/>
-			</xsl:otherwise>
-		</xsl:choose>
+		<skipped message="{./message}"/>
 	</xsl:template>
 
 	<xsl:template match="test-suite/reason"/>
@@ -208,27 +190,6 @@ This test case was reported as a "Warning" in NUnit, but converted to "Fail" by 
 
 			<xsl:otherwise>
 				<xsl:value-of select="$string" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
-
-	<!-- source: https://stackoverflow.com/a/10528912 -->
-	<xsl:template name="string-replace-all">
-		<xsl:param name="text" />
-		<xsl:param name="replace" />
-		<xsl:param name="by" />
-		<xsl:choose>
-			<xsl:when test="contains($text, $replace)">
-			<xsl:value-of select="substring-before($text,$replace)" />
-			<xsl:value-of select="$by" />
-			<xsl:call-template name="string-replace-all">
-				<xsl:with-param name="text" select="substring-after($text,$replace)" />
-				<xsl:with-param name="replace" select="$replace" />
-				<xsl:with-param name="by" select="$by" />
-			</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-			<xsl:value-of select="$text" />
 			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>

--- a/src/main/resources/hudson/plugins/nunit/nunit-warn-to-fail.xsl
+++ b/src/main/resources/hudson/plugins/nunit/nunit-warn-to-fail.xsl
@@ -12,28 +12,28 @@
 	</xsl:template>
 
 	<!-- update the total count for test-suite to include the sum of all pass + fail + warnings -->
-	<xsl:template match="test-suite/@total">
+	<xsl:template match="test-suite/@total|test-run/@total">
         <xsl:attribute name="total">
 			<xsl:value-of select="count(//assertion[@result = 'Failed'])+count(//assertion[@result = 'Warning'])+count(//assertion[@result = 'Pass'])"/>
 		</xsl:attribute>
     </xsl:template>
 
 	<!-- update the failed count for test-suite to include the sum of all fail + warnings -->
-	<xsl:template match="test-suite/@failed">
+	<xsl:template match="test-suite/@failed|test-run/@failed">
         <xsl:attribute name="failed">
 			<xsl:value-of select="count(//assertion[@result = 'Failed'])+count(//assertion[@result = 'Warning'])"/>
 		</xsl:attribute>
     </xsl:template>
 
 	<!-- update the warnings count for test-suite to 0 since we're converting all warnings to failures (with a comment) -->
-	<xsl:template match="test-suite/@warnings">
+	<xsl:template match="test-suite/@warnings|test-run/@warnings">
         <xsl:attribute name="warnings">
 			<xsl:value-of select="0"/>
 		</xsl:attribute>
     </xsl:template>
 
 	<!-- probably don't really need this, but do it anyway -->
-	<xsl:template match="test-suite/@passed">
+	<xsl:template match="test-suite/@passed|test-run/@passed">
         <xsl:attribute name="passed">
 			<xsl:value-of select="count(//assertion[@result = 'Passed'])"/>
 		</xsl:attribute>

--- a/src/main/resources/hudson/plugins/nunit/nunit-warn-to-fail.xsl
+++ b/src/main/resources/hudson/plugins/nunit/nunit-warn-to-fail.xsl
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:output method="xml" indent="yes" cdata-section-elements="system-out system-err message stack-trace" />
+
+	<!-- NUnit3 results format -->
+	<xsl:template match="node()|@*">
+ 		 <xsl:copy>
+		  <!-- copy original, but change property: https://stackoverflow.com/questions/615875/xslt-how-to-change-an-attribute-value-during-xslcopy -->
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+	</xsl:template>
+
+	<!-- update the total count for test-suite to include the sum of all pass + fail + warnings -->
+	<xsl:template match="test-suite/@total">
+        <xsl:attribute name="total">
+			<xsl:value-of select="count(//assertion[@result = 'Failed'])+count(//assertion[@result = 'Warning'])+count(//assertion[@result = 'Pass'])"/>
+		</xsl:attribute>
+    </xsl:template>
+
+	<!-- update the failed count for test-suite to include the sum of all fail + warnings -->
+	<xsl:template match="test-suite/@failed">
+        <xsl:attribute name="failed">
+			<xsl:value-of select="count(//assertion[@result = 'Failed'])+count(//assertion[@result = 'Warning'])"/>
+		</xsl:attribute>
+    </xsl:template>
+
+	<!-- update the warnings count for test-suite to 0 since we're converting all warnings to failures (with a comment) -->
+	<xsl:template match="test-suite/@warnings">
+        <xsl:attribute name="warnings">
+			<xsl:value-of select="0"/>
+		</xsl:attribute>
+    </xsl:template>
+
+	<!-- probably don't really need this, but do it anyway -->
+	<xsl:template match="test-suite/@passed">
+        <xsl:attribute name="passed">
+			<xsl:value-of select="count(//assertion[@result = 'Passed'])"/>
+		</xsl:attribute>
+    </xsl:template>
+
+	<!-- convert any reason where the result is Warning to a failure. -->
+	<xsl:template match="test-case/reason">
+		 <xsl:choose>
+    		<xsl:when test="../@result ='Warning'">
+				<failure>
+				 <message><xsl:value-of select="./message" />
+				 
+This test case was reported as a "Warning" in NUnit, but converted to "Fail" by Jenkins NUnuit Plugin
+</message>
+				</failure>
+			</xsl:when>
+			<xsl:otherwise>
+				<skipped message="{./message}"/>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<!-- copy any assertion nodes which were warnings, but apply formatting -->
+
+	<xsl:template match="assertion[@result = 'Warning']">
+		<xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+	</xsl:template>
+
+	<!-- transform the result property of any assertion from warning to failure -->
+	<xsl:template match="assertion[@result = 'Warning']/@result">
+        <xsl:attribute name="result">Failed</xsl:attribute>
+    </xsl:template>
+
+
+	<!-- source: https://www.oxygenxml.com/archives/xsl-list/200102/msg00838.html -->
+	<xsl:template name="lastIndexOf">
+		<!-- declare that it takes two parameters - the string and the char -->
+		<xsl:param name="string" />
+		<xsl:param name="char" />
+
+		<xsl:choose>
+			<!-- if the string contains the character... -->
+			<xsl:when test="contains($string, $char)">
+				<xsl:call-template name="lastIndexOf">
+					<xsl:with-param name="string"
+									select="substring-after($string, $char)" />
+					<xsl:with-param name="char" select="$char" />
+				</xsl:call-template>
+			</xsl:when>
+
+			<xsl:otherwise>
+				<xsl:value-of select="$string" />
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<!-- source: https://stackoverflow.com/a/10528912 -->
+	<xsl:template name="string-replace-all">
+		<xsl:param name="text" />
+		<xsl:param name="replace" />
+		<xsl:param name="by" />
+		<xsl:choose>
+			<xsl:when test="contains($text, $replace)">
+			<xsl:value-of select="substring-before($text,$replace)" />
+			<xsl:value-of select="$by" />
+			<xsl:call-template name="string-replace-all">
+				<xsl:with-param name="text" select="substring-after($text,$replace)" />
+				<xsl:with-param name="replace" select="$replace" />
+				<xsl:with-param name="by" select="$by" />
+			</xsl:call-template>
+			</xsl:when>
+			<xsl:otherwise>
+			<xsl:value-of select="$text" />
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+</xsl:stylesheet>

--- a/src/test/resources/hudson/plugins/nunit/NUnit-issue56241-failure.xml
+++ b/src/test/resources/hudson/plugins/nunit/NUnit-issue56241-failure.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<test-run id="2" testcasecount="1" result="Failed" total="1" passed="0" failed="1" inconclusive="0" skipped="0" asserts="0" engine-version="3.9.0.0" clr-version="4.0.30319.42000" start-time="2019-02-25 16:59:00Z" end-time="2019-02-25 16:59:00Z" duration="0.863362">
+  <command-line><![CDATA["C:\ProgramData\chocolatey\lib\nunit-console-runner\tools\nunit3-console.exe" .\UnitTestProject1.dll]]></command-line>
+  <test-suite type="Assembly" id="0-1002" name="UnitTestProject1.dll" fullname="UnitTestProject1.dll" runstate="Runnable" testcasecount="1" result="Failed" site="Child" start-time="2019-02-25 16:59:00Z" end-time="2019-02-25 16:59:00Z" duration="0.153468" total="1" passed="0" failed="1" warnings="0" inconclusive="0" skipped="0" asserts="0">
+    <environment framework-version="3.11.0.0" clr-version="4.0.30319.42000" os-version="Microsoft Windows NT 10.0.17763.0" platform="Win32NT" cwd="C:\Users\user\source\repos\UnitTestProject1\bin\Debug" machine-name="machine.name" user="user" user-domain="domain" culture="en-US" uiculture="en-US" os-architecture="x64" />
+    <settings>
+      <setting name="DisposeRunners" value="True" />
+      <setting name="WorkDirectory" value="C:\Users\user\source\repos\UnitTestProject1\bin\Debug" />
+      <setting name="ImageRuntimeVersion" value="4.0.30319" />
+      <setting name="ImageTargetFrameworkName" value=".NETFramework,Version=v4.6.1" />
+      <setting name="ImageRequiresX86" value="False" />
+      <setting name="ImageRequiresDefaultAppDomainAssemblyResolver" value="False" />
+      <setting name="NumberOfTestWorkers" value="16" />
+    </settings>
+    <properties>
+      <property name="_PID" value="18040" />
+      <property name="_APPDOMAIN" value="domain-" />
+    </properties>
+    <failure>
+      <message><![CDATA[One or more child tests had errors]]></message>
+    </failure>
+    <test-suite type="TestSuite" id="0-1003" name="UnitTestProject1" fullname="UnitTestProject1" runstate="Runnable" testcasecount="1" result="Failed" site="Child" start-time="2019-02-25 16:59:00Z" end-time="2019-02-25 16:59:00Z" duration="0.126457" total="1" passed="0" failed="1" warnings="0" inconclusive="0" skipped="0" asserts="0">
+      <failure>
+        <message><![CDATA[One or more child tests had errors]]></message>
+      </failure>
+      <test-suite type="TestFixture" id="0-1000" name="UnitTest1" fullname="UnitTestProject1.UnitTest1" classname="UnitTestProject1.UnitTest1" runstate="Runnable" testcasecount="1" result="Failed" site="Child" start-time="2019-02-25 16:59:00Z" end-time="2019-02-25 16:59:00Z" duration="0.120070" total="1" passed="0" failed="1" warnings="0" inconclusive="0" skipped="0" asserts="0">
+        <failure>
+          <message><![CDATA[One or more child tests had errors]]></message>
+        </failure>
+        <test-case id="0-1001" name="TestMethod1" fullname="UnitTestProject1.UnitTest1.TestMethod1" methodname="TestMethod1" classname="UnitTestProject1.UnitTest1" runstate="Runnable" seed="1815418348" result="Failed" start-time="2019-02-25 16:59:00Z" end-time="2019-02-25 16:59:00Z" duration="0.105781" asserts="0">
+          <failure>
+            <message><![CDATA[Example Warning Messages]]></message>
+            <stack-trace><![CDATA[   at UnitTestProject1.UnitTest1.TestMethod1() in C:\Users\user\source\repos\UnitTestProject1\UnitTest1.cs:line 31
+]]></stack-trace>
+          </failure>
+          <assertions>
+            <assertion result="Failed">
+              <message><![CDATA[Example Warning Messages]]></message>
+              <stack-trace><![CDATA[   at UnitTestProject1.UnitTest1.TestMethod1() in C:\Users\user\source\repos\UnitTestProject1\UnitTest1.cs:line 31
+]]></stack-trace>
+            </assertion>
+          </assertions>
+        </test-case>
+      </test-suite>
+    </test-suite>
+  </test-suite>
+</test-run>

--- a/src/test/resources/hudson/plugins/nunit/NUnit-issue56241-warning.xml
+++ b/src/test/resources/hudson/plugins/nunit/NUnit-issue56241-warning.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<test-run id="2" testcasecount="1" result="Warning" total="0" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" engine-version="3.9.0.0" clr-version="4.0.30319.42000" start-time="2019-02-22 18:30:28Z" end-time="2019-02-22 18:30:29Z" duration="0.864052">
+  <command-line><![CDATA["C:\ProgramData\chocolatey\lib\nunit-console-runner\tools\nunit3-console.exe" .\UnitTestProject1.dll]]></command-line>
+  <test-suite type="Assembly" id="0-1002" name="UnitTestProject1.dll" fullname="UnitTestProject1.dll" runstate="Runnable" testcasecount="1" result="Warning" site="Child" start-time="2019-02-22 18:30:29Z" end-time="2019-02-22 18:30:29Z" duration="0.154658" total="0" passed="0" failed="0" warnings="1" inconclusive="0" skipped="0" asserts="0">
+    <environment framework-version="3.11.0.0" clr-version="4.0.30319.42000" os-version="Microsoft Windows NT 10.0.17763.0" platform="Win32NT" cwd="C:\Users\user\source\repos\UnitTestProject1\bin\Debug" machine-name="machine.name" user="user" user-domain="domain" culture="en-US" uiculture="en-US" os-architecture="x64" />
+    <settings>
+      <setting name="DisposeRunners" value="True" />
+      <setting name="WorkDirectory" value="C:\Users\user\source\repos\UnitTestProject1\bin\Debug" />
+      <setting name="ImageRuntimeVersion" value="4.0.30319" />
+      <setting name="ImageTargetFrameworkName" value=".NETFramework,Version=v4.6.1" />
+      <setting name="ImageRequiresX86" value="False" />
+      <setting name="ImageRequiresDefaultAppDomainAssemblyResolver" value="False" />
+      <setting name="NumberOfTestWorkers" value="16" />
+    </settings>
+    <properties>
+      <property name="_PID" value="2412" />
+      <property name="_APPDOMAIN" value="domain-" />
+    </properties>
+    <reason>
+      <message><![CDATA[One or more child tests had warnings]]></message>
+    </reason>
+    <test-suite type="TestSuite" id="0-1003" name="UnitTestProject1" fullname="UnitTestProject1" runstate="Runnable" testcasecount="1" result="Warning" site="Child" start-time="2019-02-22 18:30:29Z" end-time="2019-02-22 18:30:29Z" duration="0.127092" total="0" passed="0" failed="0" warnings="1" inconclusive="0" skipped="0" asserts="0">
+      <reason>
+        <message><![CDATA[One or more child tests had warnings]]></message>
+      </reason>
+      <test-suite type="TestFixture" id="0-1000" name="UnitTest1" fullname="UnitTestProject1.UnitTest1" classname="UnitTestProject1.UnitTest1" runstate="Runnable" testcasecount="1" result="Warning" site="Child" start-time="2019-02-22 18:30:29Z" end-time="2019-02-22 18:30:29Z" duration="0.119439" total="0" passed="0" failed="0" warnings="1" inconclusive="0" skipped="0" asserts="0">
+        <reason>
+          <message><![CDATA[One or more child tests had warnings]]></message>
+        </reason>
+        <test-case id="0-1001" name="TestMethod1" fullname="UnitTestProject1.UnitTest1.TestMethod1" methodname="TestMethod1" classname="UnitTestProject1.UnitTest1" runstate="Runnable" seed="2044112344" result="Warning" start-time="2019-02-22 18:30:29Z" end-time="2019-02-22 18:30:29Z" duration="0.102436" asserts="0">
+          <reason>
+            <message><![CDATA[Example Warning Messages]]></message>
+          </reason>
+          <assertions>
+            <assertion result="Warning">
+              <message><![CDATA[Example Warning Messages]]></message>
+              <stack-trace><![CDATA[   at UnitTestProject1.UnitTest1.TestMethod1() in C:\Users\user\source\repos\UnitTestProject1\UnitTest1.cs:line 31
+]]></stack-trace>
+            </assertion>
+          </assertions>
+        </test-case>
+      </test-suite>
+    </test-suite>
+  </test-suite>
+</test-run>


### PR DESCRIPTION
Currently, NUnit tests with a status of "Warning" are interpreted as "skipped" in the Jenkins UI (https://issues.jenkins-ci.org/browse/JENKINS-56241) 

There does not appear to be a direct mapping of "Warning" to the JUnit test result type, which appears to be the "intermediate" step for importing NUnit tests into Jenkins. 

This causes the NUnit Jenkins plugin to treat tests with status of "Warning" as a "Fail" rather than a "Skip."

Since "Warning" tests don't include a stack trace, the stack trace field in the JUnit test result is a string indicating: `This test case was reported as a "Warning" in NUnit, but converted to "Fail" by Jenkins NUnuit Plugin`.

I am opening this PR as a draft, since I want to make this behavior configurable, with the end goal of the following:

*  NUnit warnings -> Jenkins build unstable if `warningTestsUnstableBuild:true`

