### PR TITLE
Fix corruption around multibyte character

### DIFF
--- a/src/main/java/hudson/plugins/nunit/InvalidXmlInputStream.java
+++ b/src/main/java/hudson/plugins/nunit/InvalidXmlInputStream.java
@@ -62,7 +62,7 @@ public class InvalidXmlInputStream extends ProxyInputStream {
 
         int pos = off - 1;
         for (int readPos = off; readPos < off + read; readPos++) {
-            if (!isValid(cbuf[readPos])) {
+            if (!isValid(Byte.toUnsignedInt(cbuf[readPos]))) {
                 cbuf[readPos] = replacement;
             }
             pos++;


### PR DESCRIPTION
<details>
<summary>sample file</summary>

```xml
<?xml version="1.0" encoding="utf-8"?>
<test-run id="2" testcasecount="4" result="Failed(Child)" total="4" passed="2" failed="2" inconclusive="0" skipped="0" asserts="0" engine-version="3.5.0.0" clr-version="4.0.30319.42000" start-time="2019-12-06 04:28:36Z" end-time="2019-12-06 04:28:36Z" duration="0.0862346">
  <test-suite type="TestSuite" id="1009" name="ForTest" fullname="ForTest" runstate="Runnable" testcasecount="4" result="Failed" site="Child" start-time="2019-12-06 04:28:36Z" end-time="2019-12-06 04:28:36Z" duration="0.086235" total="4" passed="2" failed="2" inconclusive="0" skipped="0" asserts="0">
    <properties />
    <failure>
      <message><![CDATA[One or more child tests had errors]]></message>
    </failure>
    <test-suite type="Assembly" id="1015" name="Tests.dll" fullname="D:/ForTest/Library/ScriptAssemblies/Tests.dll" runstate="Runnable" testcasecount="4" result="Failed" site="Child" start-time="2019-12-06 04:28:36Z" end-time="2019-12-06 04:28:36Z" duration="0.068185" total="4" passed="2" failed="2" inconclusive="0" skipped="0" asserts="0">
      <properties>
        <property name="_PID" value="16232" />
        <property name="_APPDOMAIN" value="Unity Child Domain" />
        <property name="platform" value="EditMode" />
      </properties>
      <failure>
        <message><![CDATA[One or more child tests had errors]]></message>
      </failure>
      <test-suite type="TestSuite" id="1016" name="Tests" fullname="Tests" runstate="Runnable" testcasecount="4" result="Failed" site="Child" start-time="2019-12-06 04:28:36Z" end-time="2019-12-06 04:28:36Z" duration="0.064767" total="4" passed="2" failed="2" inconclusive="0" skipped="0" asserts="0">
        <properties />
        <failure>
          <message><![CDATA[One or more child tests had errors]]></message>
        </failure>
        <test-suite type="TestFixture" id="1010" name="SampleTest" fullname="Tests.SampleTest" classname="Tests.SampleTest" runstate="Runnable" testcasecount="4" result="Failed" site="Child" start-time="2019-12-06 04:28:36Z" end-time="2019-12-06 04:28:36Z" duration="0.053100" total="4" passed="2" failed="2" inconclusive="0" skipped="0" asserts="0">
          <properties />
          <failure>
            <message><![CDATA[One or more child tests had errors]]></message>
          </failure>
          <test-case id="1012" name="FailTest" fullname="Tests.SampleTest.FailTest" methodname="FailTest" classname="Tests.SampleTest" runstate="Runnable" seed="1266601284" result="Failed" start-time="2019-12-06 04:28:36Z" end-time="2019-12-06 04:28:36Z" duration="0.021695" asserts="0">
            <properties />
            <failure>
              <message><![CDATA[  Expected: True
  But was:  False
]]></message>
              <stack-trace><![CDATA[at Tests.SampleTest.FailTest () [0x00001] in D:\ForTest\Assets\Tests\SampleTest.cs:17
]]></stack-trace>
            </failure>
          </test-case>
          <test-case id="1011" name="NormalTest" fullname="Tests.SampleTest.NormalTest" methodname="NormalTest" classname="Tests.SampleTest" runstate="Runnable" seed="1505688924" result="Passed" start-time="2019-12-06 04:28:36Z" end-time="2019-12-06 04:28:36Z" duration="0.002818" asserts="0">
            <properties />
          </test-case>
          <test-case id="1013" name="日本語テスト" fullname="Tests.SampleTest.日本語テスト" methodname="日本語テスト" classname="Tests.SampleTest" runstate="Runnable" seed="1220957110" result="Passed" start-time="2019-12-06 04:28:36Z" end-time="2019-12-06 04:28:36Z" duration="0.000488" asserts="0">
            <properties />
          </test-case>
          <test-case id="1014" name="日本語失敗テスト" fullname="Tests.SampleTest.日本語失敗テスト" methodname="日本語失敗テスト" classname="Tests.SampleTest" runstate="Runnable" seed="1053433831" result="Failed" start-time="2019-12-06 04:28:36Z" end-time="2019-12-06 04:28:36Z" duration="0.001889" asserts="0">
            <properties />
            <failure>
              <message><![CDATA[  Expected: True
  But was:  False
]]></message>
              <stack-trace><![CDATA[at Tests.SampleTest.日本語失敗テスト () [0x00001] in D:\ForTest\Assets\Tests\SampleTest.cs:28
]]></stack-trace>
            </failure>
          </test-case>
        </test-suite>
      </test-suite>
    </test-suite>
  </test-suite>
</test-run>
```

</details>