### PR TITLE
Add Declarative pipeline sample code to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@
 This plugin allows you to publish [NUnit](http://www.nunit.org/) test results.
 
 ## Pipeline example
+
+For more information refer to [NUnit Pipeline Steps](https://www.jenkins.io/doc/pipeline/steps/nunit/)
+
+### For Scripted pipeline
+
 ```
 node {
 
@@ -27,7 +32,29 @@ node {
 }
 ```
 
-For more information refer to [NUnit Pipeline Steps](https://www.jenkins.io/doc/pipeline/steps/nunit/)
+### For Declarative pipeline
+
+```
+pipeline {
+    agent any
+
+    ...
+
+    stages {
+
+        ...
+
+        stage("Publish NUnit Test Report") {
+            steps {
+                nunit testResultsPattern: 'TestResult.xml'
+            }
+        }
+
+        ...
+
+    }
+}
+```
 
 ## Version History
 


### PR DESCRIPTION
I was trying to utilize this plugin, and copypasting the code from README gave me a syntax error.
In the end, I found that the code sample here was for the Scripted pipeline.
So I am providing another sample for the Declarative pipeline too.

My system:
Jenkins v.2.263.1
nunit plugin v0.27

Part of my build log:
```
...
20:28:29  org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
20:28:29  WorkflowScript: 103: Unknown stage section "nunit". Starting with version 0.5, steps in a stage must be in a ‘steps’ block. @ line 103, column 9.
20:28:29             stage("Publish NUnit Test Report") {
20:28:29             ^
20:28:29  
20:28:29  WorkflowScript: 103: Expected one of "steps", "stages", or "parallel" for stage "Publish NUnit Test Report" @ line 103, column 9.
20:28:29             stage("Publish NUnit Test Report") {
20:28:29             ^
20:28:29  
20:28:29  2 errors
20:28:29  
20:28:29  	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:310)
20:28:29  	at org.codehaus.groovy.control.CompilationUnit.applyToPrimaryClassNodes(CompilationUnit.java:1085)
20:28:29  	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:603)
20:28:29  	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:581)
20:28:29  	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:558)
20:28:29  	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298)
20:28:29  	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268)
20:28:29  	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:688)
20:28:29  	at groovy.lang.GroovyShell.parse(GroovyShell.java:700)
20:28:29  	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:142)
20:28:29  	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:127)
20:28:29  	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:571)
20:28:29  	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:523)
20:28:29  	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:337)
20:28:29  	at hudson.model.ResourceController.execute(ResourceController.java:97)
20:28:29  	at hudson.model.Executor.run(Executor.java:429)
20:28:29  Finished: FAILURE
...
```

