### PR TITLE
Bump Jenkins core to 2.414.1 and fix pom dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,6 @@ buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 17],
-    [platform: 'linux',   jdk: '21', jenkins: '2.414'],
+    [platform: 'linux',   jdk: 21],
     [platform: 'windows', jdk: 11],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,14 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/nunit-plugin</gitHubRepo>
-        <jenkins.version>2.401.3</jenkins.version>
+        <jenkins.version>2.414.1</jenkins.version>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.401.x</artifactId>
-                <version>2401.v7a_d68f8d0b_09</version>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2423.vce598171d115</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -41,6 +41,14 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-text-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Bump Jenkins core to 2.414.1 and fix pom dependencies

### Testing done

CI

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
