### PR TITLE
Bugfix: Skipped tests incorrectly displayed as passed

### DIFF
--- a/src/main/resources/hudson/plugins/nunit/nunit-to-junit.xsl
+++ b/src/main/resources/hudson/plugins/nunit/nunit-to-junit.xsl
@@ -115,7 +115,7 @@ STACK TRACE:
 
 	<xsl:template match="test-suite">
 		<xsl:if test="test-case">
-			<testsuite tests="{@testcasecount}" time="{@duration}" errors="{@testcasecount - @passed - @skipped - @failed - @inconclusive}" failures="{@failed}" skipped="{@skipped + @inconclusive}" timestamp="{@start-time}">
+			<testsuite tests="{count(descendant::test-case)}" time="{@duration}" errors="{count(descendant::test-case) - @passed - @skipped - @failed - @inconclusive}" failures="{@failed}" skipped="{@skipped + @inconclusive}" timestamp="{@start-time}">
 				<xsl:attribute name="name">
 					<xsl:for-each select="ancestor-or-self::test-suite/@name">
 						<xsl:value-of select="concat(., '.')"/>
@@ -135,8 +135,12 @@ STACK TRACE:
 
 	<xsl:template match="test-case">
 		<testcase name="{@name}" assertions="{@asserts}" time="{@duration}" status="{@result}" classname="{@classname}">
-			<xsl:if test="@runstate = 'Skipped' or @runstate = 'Ignored' or @runstate='Inconclusive'">
-				<skipped/>
+			<xsl:if test="@result = 'Skipped' or @runstate = 'Skipped' or @runstate = 'Ignored' or @runstate='Inconclusive'">
+				<skipped>
+					<xsl:attribute name="message">
+						<xsl:value-of select="./reason/message"/>
+					</xsl:attribute>
+				</skipped>
 			</xsl:if>
 
 			<xsl:apply-templates/>

--- a/src/test/java/hudson/plugins/nunit/NUnitToJUnitXslTest.java
+++ b/src/test/java/hudson/plugins/nunit/NUnitToJUnitXslTest.java
@@ -134,6 +134,17 @@ public class NUnitToJUnitXslTest {
         assertTrue("XSL transformation did not work. " + myDiff, myDiff.similar());
     }
 
+    @Test
+    public void testTransformationHandlesSkippedTestsIssue110() throws Exception {
+        Transform myTransform = new Transform(
+                new InputSource(this.getClass().getResourceAsStream("NUnit-issue110.xml")),
+                new InputSource(
+                        this.getClass().getResourceAsStream(NUnitReportTransformer.NUNIT_TO_JUNIT_XSLFILE_STR)));
+
+        Diff myDiff = new Diff(readXmlAsString("JUnit-issue110.xml"), myTransform);
+        assertTrue("XSL transformation did not correctly handle skipped tests. " + myDiff, myDiff.similar());
+    }
+
     private String readXmlAsString(String resourceName) throws IOException {
         String xmlString = "";
 

--- a/src/test/resources/hudson/plugins/nunit/JUnit-issue110.xml
+++ b/src/test/resources/hudson/plugins/nunit/JUnit-issue110.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?><testsuites tests="23" failures="1" disabled="1" time="0.05420000000000001">
+      
+    
+      
+    <testsuite tests="23" time="0.0542" errors="0" failures="1" skipped="1" timestamp="2025-01-13T10:50:40Z" name="Money.dll.Money.MoneyTest.">
+        <testcase name="BagMultiply" assertions="0" time="0.017791" status="Passed" classname="MoneyTest"/>
+        <testcase name="BagNegate" assertions="0" time="0.000336" status="Passed" classname="MoneyTest"/>
+        <testcase name="BagSimpleAdd" assertions="0" time="0.000616" status="Passed" classname="MoneyTest"/>
+        <testcase name="BagSubtract" assertions="0" time="0.000262" status="Passed" classname="MoneyTest"/>
+        <testcase name="BagSumAdd" assertions="0" time="0.000119" status="Passed" classname="MoneyTest"/>
+        <testcase name="FailedTest" assertions="0" time="0.031292" status="Failed" classname="MoneyTest">
+                      
+            <failure message="  A failure message for the failed test.&#10;Assert.That(false, Is.EqualTo(true))&#10;  Expected: True&#10;  But was:  False&#10;">   at Money.MoneyTest.FailedTest() in C:\Users\USER\OpenSourceProjects\nunit-csharp-samples\money\MoneyTest.cs:line 336
+
+1)    at Money.MoneyTest.FailedTest() in C:\Users\user\OpenSourceProjects\nunit-csharp-samples\money\MoneyTest.cs:line 336
+
+</failure>
+                    
+        </testcase>
+        <testcase name="IgnoredTest" assertions="0" time="0.000132" status="Skipped" classname="MoneyTest">
+            <skipped message=""/>
+                      
+            <system-out><![CDATA[Ignoring to check correct skipped status and reason message
+]]></system-out>
+                    
+        </testcase>
+        <testcase name="IsZero" assertions="0" time="0.000125" status="Passed" classname="MoneyTest"/>
+        <testcase name="MixedSimpleAdd" assertions="0" time="0.000134" status="Passed" classname="MoneyTest"/>
+        <testcase name="MoneyBagEquals" assertions="0" time="0.000287" status="Passed" classname="MoneyTest"/>
+        <testcase name="MoneyBagHash" assertions="0" time="0.001172" status="Passed" classname="MoneyTest"/>
+        <testcase name="MoneyEquals" assertions="0" time="0.000103" status="Passed" classname="MoneyTest"/>
+        <testcase name="MoneyHash" assertions="0" time="0.000132" status="Passed" classname="MoneyTest"/>
+        <testcase name="Normalize" assertions="0" time="0.000156" status="Passed" classname="MoneyTest"/>
+        <testcase name="Normalize2" assertions="0" time="0.000118" status="Passed" classname="MoneyTest"/>
+        <testcase name="Normalize3" assertions="0" time="0.000127" status="Passed" classname="MoneyTest"/>
+        <testcase name="Normalize4" assertions="0" time="0.000168" status="Passed" classname="MoneyTest"/>
+        <testcase name="Print" assertions="0" time="0.000624" status="Passed" classname="MoneyTest"/>
+        <testcase name="SimpleAdd" assertions="0" time="0.000105" status="Passed" classname="MoneyTest"/>
+        <testcase name="SimpleBagAdd" assertions="0" time="0.000123" status="Passed" classname="MoneyTest"/>
+        <testcase name="SimpleMultiply" assertions="0" time="9.7E-05" status="Passed" classname="MoneyTest"/>
+        <testcase name="SimpleNegate" assertions="0" time="8.9E-05" status="Passed" classname="MoneyTest"/>
+        <testcase name="SimpleSubtract" assertions="0" time="9.2E-05" status="Passed" classname="MoneyTest"/>
+    </testsuite>
+        
+    
+  
+
+</testsuites>

--- a/src/test/resources/hudson/plugins/nunit/NUnit-issue110.xml
+++ b/src/test/resources/hudson/plugins/nunit/NUnit-issue110.xml
@@ -1,0 +1,48 @@
+<test-run id="2" duration="0.05420000000000001" testcasecount="23" total="23" passed="21" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2025-01-13T10:50:39Z" end-time="2025-01-13T10:50:40Z">
+  <test-suite type="Assembly" name="Money.dll" fullname="C:\Users\user\OpenSourceProjects\nunit-csharp-samples\money\bin\Debug\net6.0\Money.dll" total="23" passed="21" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.0542">
+    <test-suite type="TestSuite" name="Money" fullname="Money" total="23" passed="21" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.0542">
+      <test-suite type="TestFixture" name="MoneyTest" fullname="Money.MoneyTest" classname="Money.MoneyTest" total="23" passed="21" failed="1" inconclusive="0" skipped="1" result="Failed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.0542">
+        <test-case name="BagMultiply" fullname="Money.MoneyTest.BagMultiply" methodname="BagMultiply" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.017791" asserts="0" seed="1085017776" />
+        <test-case name="BagNegate" fullname="Money.MoneyTest.BagNegate" methodname="BagNegate" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000336" asserts="0" seed="396754680" />
+        <test-case name="BagSimpleAdd" fullname="Money.MoneyTest.BagSimpleAdd" methodname="BagSimpleAdd" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000616" asserts="0" seed="145216565" />
+        <test-case name="BagSubtract" fullname="Money.MoneyTest.BagSubtract" methodname="BagSubtract" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000262" asserts="0" seed="706382434" />
+        <test-case name="BagSumAdd" fullname="Money.MoneyTest.BagSumAdd" methodname="BagSumAdd" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000119" asserts="0" seed="1661027999" />
+        <test-case name="FailedTest" fullname="Money.MoneyTest.FailedTest" methodname="FailedTest" classname="MoneyTest" result="Failed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.031292" asserts="0" seed="1029712172">
+          <failure>
+            <message>  A failure message for the failed test.
+Assert.That(false, Is.EqualTo(true))
+  Expected: True
+  But was:  False
+</message>
+            <stack-trace>   at Money.MoneyTest.FailedTest() in C:\Users\USER\OpenSourceProjects\nunit-csharp-samples\money\MoneyTest.cs:line 336
+
+1)    at Money.MoneyTest.FailedTest() in C:\Users\user\OpenSourceProjects\nunit-csharp-samples\money\MoneyTest.cs:line 336
+
+</stack-trace>
+          </failure>
+        </test-case>
+        <test-case name="IgnoredTest" fullname="Money.MoneyTest.IgnoredTest" methodname="IgnoredTest" classname="MoneyTest" result="Skipped" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000132" asserts="0" seed="1341007051">
+          <output><![CDATA[Ignoring to check correct skipped status and reason message
+]]></output>
+        </test-case>
+        <test-case name="IsZero" fullname="Money.MoneyTest.IsZero" methodname="IsZero" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000125" asserts="0" seed="1322466791" />
+        <test-case name="MixedSimpleAdd" fullname="Money.MoneyTest.MixedSimpleAdd" methodname="MixedSimpleAdd" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000134" asserts="0" seed="1667425364" />
+        <test-case name="MoneyBagEquals" fullname="Money.MoneyTest.MoneyBagEquals" methodname="MoneyBagEquals" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000287" asserts="0" seed="769551084" />
+        <test-case name="MoneyBagHash" fullname="Money.MoneyTest.MoneyBagHash" methodname="MoneyBagHash" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.001172" asserts="0" seed="1920822432" />
+        <test-case name="MoneyEquals" fullname="Money.MoneyTest.MoneyEquals" methodname="MoneyEquals" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000103" asserts="0" seed="1441461003" />
+        <test-case name="MoneyHash" fullname="Money.MoneyTest.MoneyHash" methodname="MoneyHash" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000132" asserts="0" seed="886961537" />
+        <test-case name="Normalize" fullname="Money.MoneyTest.Normalize" methodname="Normalize" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000156" asserts="0" seed="12811720" />
+        <test-case name="Normalize2" fullname="Money.MoneyTest.Normalize2" methodname="Normalize2" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000118" asserts="0" seed="173285473" />
+        <test-case name="Normalize3" fullname="Money.MoneyTest.Normalize3" methodname="Normalize3" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000127" asserts="0" seed="1697705121" />
+        <test-case name="Normalize4" fullname="Money.MoneyTest.Normalize4" methodname="Normalize4" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000168" asserts="0" seed="1641232691" />
+        <test-case name="Print" fullname="Money.MoneyTest.Print" methodname="Print" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000624" asserts="0" seed="1811977792" />
+        <test-case name="SimpleAdd" fullname="Money.MoneyTest.SimpleAdd" methodname="SimpleAdd" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000105" asserts="0" seed="306639982" />
+        <test-case name="SimpleBagAdd" fullname="Money.MoneyTest.SimpleBagAdd" methodname="SimpleBagAdd" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="0.000123" asserts="0" seed="1035804096" />
+        <test-case name="SimpleMultiply" fullname="Money.MoneyTest.SimpleMultiply" methodname="SimpleMultiply" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="9.7E-05" asserts="0" seed="1202483758" />
+        <test-case name="SimpleNegate" fullname="Money.MoneyTest.SimpleNegate" methodname="SimpleNegate" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="8.9E-05" asserts="0" seed="1758910059" />
+        <test-case name="SimpleSubtract" fullname="Money.MoneyTest.SimpleSubtract" methodname="SimpleSubtract" classname="MoneyTest" result="Passed" start-time="2025-01-13T10:50:40Z" end-time="2025-01-13T10:50:40Z" duration="9.2E-05" asserts="0" seed="199262483" />
+      </test-suite>
+    </test-suite>
+    <errors />
+  </test-suite>
+</test-run>


### PR DESCRIPTION
- Correct handling of skipped tests to ensure proper reporting: `@result = 'Skipped'` .
- Improved error and tests calculation logic: tests="0" and errors="NaN".
- Unit test and resources.

Related issue - https://github.com/jenkinsci/nunit-plugin/issues/110

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
![image](https://github.com/user-attachments/assets/5ca24aa9-fb11-41b9-b1c7-dfc9a8f1d200)

![image](https://github.com/user-attachments/assets/fbd5a325-6ea8-4552-aacc-b5a5b2f3f6b6)

